### PR TITLE
Adding a note

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ All Ethereum clients include an EVM implementation. In addition to those, there 
 
 ### Ethereum Clients (with EVM)
 - [Geth](https://geth.ethereum.org/) | Programming Language = Go
-- [OpenEthereum](https://github.com/openethereum/openethereum) | Programming Language = Rust
+- [OpenEthereum](https://github.com/openethereum/openethereum) | Programming Language = Rust (Note: This client is deprecated and no more maintained by Ethereum Foundation)
 - [Nethermind](https://nethermind.io/) | Programming Language = C# (.NET)
 - [Besu](https://consensys.net/quorum/developers/) | Programming Language = Java
 - [Erigon](https://github.com/ledgerwatch/erigon) | Programming Language = Go


### PR DESCRIPTION
OpenEthereum Client is deprecated according to this doc in ethereum.org, here is the [link](https://ethereum.org/en/developers/docs/nodes-and-clients/#execution-clients).

Discord Username: Vatsal#9559